### PR TITLE
Allow data_generator.py to run without requiring classical datasets for custom datasets

### DIFF
--- a/adbench/datasets/data_generator.py
+++ b/adbench/datasets/data_generator.py
@@ -33,7 +33,7 @@ class DataGenerator():
         self.n_samples_threshold = n_samples_threshold
 
         # dataset list
-        self.dataset_list_classical, self.dataset_list_cv, self.dataset_list_nlp = self.generate_dataset_list()
+        # self.dataset_list_classical, self.dataset_list_cv, self.dataset_list_nlp = self.generate_dataset_list()
 
         # myutils function
         self.utils = Utils()
@@ -232,6 +232,8 @@ class DataGenerator():
             assert X is not None and y is not None, "For customized dataset, you should provide the X and y!"
             print('Testing on customized dataset...')
         else:
+            self.dataset_list_classical, self.dataset_list_cv, self.dataset_list_nlp = self.generate_dataset_list()
+            
             if self.dataset in self.dataset_list_classical:
                 data = np.load(os.path.join(os.path.dirname(os.path.abspath(__file__)), 'Classical', self.dataset + '.npz'), allow_pickle=True)
             elif self.dataset in self.dataset_list_cv:


### PR DESCRIPTION
This PR updates _adbench/datasets/data_generator.py_ so that users who want to use their own **customized datasets** no longer need to download or have the classical datasets beforehand. Previously, the code required classical datasets to be present even if they weren't needed, which could be inconvenient for users working exclusively with custom data.
With this change, the data generator will skip the classical dataset dependency when custom datasets are provided, improving usability and flexibility.